### PR TITLE
fix(taskId): query params are now use trough next/navigation

### DIFF
--- a/src/app/tasks/[id]/page.tsx
+++ b/src/app/tasks/[id]/page.tsx
@@ -4,13 +4,11 @@ import { TaskDetails } from '../../modules/taskManager';
 import { Task } from '../../modules/taskManager';
 import { useEffect, useState } from 'react';
 import React from 'react';
+import { useParams } from 'next/navigation';
 
-export default function TaskDetailPage({
-  params
-}: {
-  params: { id: string }
-}) {
-    const id = params.id;
+export default function TaskDetailPage() {
+    const params = useParams();
+    const id = params?.id as string;
     const [task, setTask] = useState<Task | null>(null);
     const [isLoading, setIsLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);


### PR DESCRIPTION
## Use `useParams` from Next/Navigation

### Changes
- Refactored route parameter handling to use `useParams` hook from `next/navigation`
- Removed explicit props typing for params as they're now handled through the hook

### Why
- Aligns with Next.js client-side routing patterns
- Provides a more consistent approach to accessing route parameters
- Simplifies component props interface

### Note
While this change works, it's worth noting that for Next.js App Router page components, receiving params as props (the previous implementation) is actually the recommended approach. This PR changes to `useParams` to maintain consistency with other client components in our codebase.

### Testing
- Verified that task ID is correctly accessed and displayed
- Tested with various route parameters
- Ensured TypeScript types are properly maintained